### PR TITLE
Fix Invoice getters so they return dates in the input format

### DIFF
--- a/lib/nacre/order/invoice.rb
+++ b/lib/nacre/order/invoice.rb
@@ -11,9 +11,30 @@ module Nacre
       @due_date = DateTime.iso8601(iso_date)
     end
 
+    def due_date
+      @due_date.strftime(time_format)
+    end
+
+    def due_date_raw
+      @due_date
+    end
+
     def tax_date=(iso_date)
       @tax_date = DateTime.iso8601(iso_date)
     end
 
+    def tax_date
+      @tax_date.strftime(time_format)
+    end
+
+    def tax_date_raw
+      @tax_date
+    end
+
+    private
+
+    def time_format
+      '%Y-%m-%dT%H:%M:%S.%LZ'
+    end
   end
 end

--- a/spec/lib/nacre/order/invoice_collection_spec.rb
+++ b/spec/lib/nacre/order/invoice_collection_spec.rb
@@ -15,6 +15,8 @@ describe Nacre::Order::InvoiceCollection do
 
   it_should_behave_like 'Enumerable'
 
+  it_should_behave_like 'Parametrizable'
+
   it 'should contain invoices' do
     expect(subject.first).to be_a(Nacre::Order::Invoice)
   end

--- a/spec/lib/nacre/order/invoice_spec.rb
+++ b/spec/lib/nacre/order/invoice_spec.rb
@@ -11,18 +11,33 @@ describe Nacre::Order::Invoice do
 
   subject { described_class.new(params) }
 
-  it 'should have a due date' do
-    expect(subject.due_date).to be_a(DateTime)
-    expect(subject.due_date.to_s).to eq('2013-02-04T00:00:00+00:00')
+  describe '#invoice_reference' do
+    it 'should have the correct value' do
+      expect(subject.invoice_reference).to eq('AA-99999')
+    end
   end
 
-  it 'should have an invoice reference' do
-    expect(subject.invoice_reference).to eq('AA-99999')
+  describe '#due_date' do
+    it 'should be formatted correctly' do
+      expect(subject.due_date.to_s).to eq('2013-02-04T00:00:00.000Z')
+    end
   end
 
-  it 'should have a tax date' do
-    expect(subject.tax_date).to be_a(DateTime)
-    expect(subject.tax_date.to_s).to eq('2012-12-06T00:00:00+00:00')
+  describe '#due_date_raw' do
+    it 'should return a DateTime object' do
+      expect(subject.due_date_raw).to be_a(DateTime)
+    end
   end
 
+  describe '#tax_date' do
+    it 'should be formatted correctly' do
+      expect(subject.tax_date.to_s).to eq('2012-12-06T00:00:00.000Z')
+    end
+  end
+
+  describe '#tax_date_raw' do
+    it 'should return a DateTime object' do
+      expect(subject.tax_date_raw).to be_a(DateTime)
+    end
+  end
 end


### PR DESCRIPTION
Date getters were returning DateTime objects when they needed to return strings formatted in the same ISO-8601 variant as the Brightpearl API uses in its responses.
