### PR TITLE
Use "public-api" for URI instead of version no

### DIFF
--- a/lib/nacre/configuration.rb
+++ b/lib/nacre/configuration.rb
@@ -56,7 +56,7 @@ module Nacre
     end
 
     def default_api_version
-      ENV["NACRE_API_VERSION"] || "2.0.0"
+      "public-api"
     end
 
     def default_user_id

--- a/lib/nacre/journal/entry_collection.rb
+++ b/lib/nacre/journal/entry_collection.rb
@@ -23,5 +23,8 @@ module Nacre
       members.map(&:params)
     end
 
+    def size
+      members.size
+    end
   end
 end

--- a/spec/lib/nacre/configuration_spec.rb
+++ b/spec/lib/nacre/configuration_spec.rb
@@ -21,20 +21,28 @@ describe Nacre::Configuration do
   end
 
   context "URLs from configuration" do
+    let(:base_url) { "https://ws-eu1.brightpearl.com" }
+
+    let(:user_id) { ENV["NACRE_USER_ID"] }
+
     it "has the correct precision for money values" do
-      expect(config.value_precision).to eql("6")
+      expect(config.value_precision).to eql "6"
     end
 
     it "should have the correct base URL" do
-      expect(config.base_url).to eql("https://ws-eu1.brightpearl.com")
+      expect(config.base_url).to eql base_url
     end
 
     it "should have the correct Resource URL" do
-      expect(config.resource_url).to eql("https://ws-eu1.brightpearl.com/public-api/%s" % [ENV["NACRE_USER_ID"]])
+      expect(config.resource_url).to eql(
+        "#{base_url}/public-api/#{user_id}"
+      )
     end
 
     it "should have the correct auth URL" do
-      expect(config.auth_url).to eql("https://ws-eu1.brightpearl.com/%s/authorise" % [ ENV["NACRE_USER_ID"] ])
+      expect(config.auth_url).to eql(
+        "#{base_url}/#{user_id}/authorise"
+      )
     end
   end
 

--- a/spec/lib/nacre/configuration_spec.rb
+++ b/spec/lib/nacre/configuration_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 describe Nacre::Configuration do
 
-
   let(:config) { Nacre::Configuration.new(args) }
 
   let(:args) { {} }
@@ -31,7 +30,7 @@ describe Nacre::Configuration do
     end
 
     it "should have the correct Resource URL" do
-      expect(config.resource_url).to eql("https://ws-eu1.brightpearl.com/2.0.0/%s" % [ENV["NACRE_USER_ID"]])
+      expect(config.resource_url).to eql("https://ws-eu1.brightpearl.com/public-api/%s" % [ENV["NACRE_USER_ID"]])
     end
 
     it "should have the correct auth URL" do

--- a/spec/lib/nacre/journal/entry_collection_spec.rb
+++ b/spec/lib/nacre/journal/entry_collection_spec.rb
@@ -32,6 +32,10 @@ describe Nacre::Journal::EntryCollection do
     it "has the correct type" do
       expect(subject.type).to eq type
     end
+
+    it "has the correct number of members" do
+      expect(subject.size).to eq 1
+    end
   end
 
   context "with credit entries" do

--- a/spec/lib/nacre/journal_spec.rb
+++ b/spec/lib/nacre/journal_spec.rb
@@ -72,9 +72,17 @@ describe Nacre::Journal do
         expect(subject.credits.type).to eq :credit
       end
 
+      it "has one item in the credits collection" do
+        expect(subject.credits.size).to eq 1
+      end
+
       it "has a debits collection" do
         expect(subject.debits).to respond_to :each
         expect(subject.debits.type).to eq :debit
+      end
+
+      it "has one item in the debits collection" do
+        expect(subject.debits.size).to eq 1
       end
 
       it "has a journal_type_code" do


### PR DESCRIPTION
Brightpearl are deprecating the use of specific version numbers in the URI for their public API. Instead, you should use "public-api" in the same location within the URI.

- Change "2.0.0" to "public-api".
- Don't allow this change to be overridden in configuration.

This change will result in the config ignoring API versions being set, so the change is non-breaking.

I have tested the new URI's and they work.