### PR TITLE
Raise EmptyResourceError when API response is empty

### DIFF
--- a/lib/nacre/abstract_resource.rb
+++ b/lib/nacre/abstract_resource.rb
@@ -31,6 +31,8 @@ module Nacre
     end
 
     def attributes=(attributes_hash)
+      prevent_empty_resource! attributes_hash
+
       self.class.fields.each do |field|
         if attributes_hash.has_key?(field.to_sym)
           public_send("#{field}=", attributes_hash[field.to_sym])
@@ -55,6 +57,15 @@ module Nacre
     private
 
     def post_initialize; end
+
+    def prevent_empty_resource!(attributes_hash)
+      if attributes_hash.nil?
+        raise(
+          Nacre::EmptyResourceError,
+          "#{self.class} initialized with empty attributes."
+        )
+      end
+    end
 
     def self.list_extracted_errors(json)
       parsed_body = JSON.parse(json, symbolize_names: true)

--- a/lib/nacre/error.rb
+++ b/lib/nacre/error.rb
@@ -6,3 +6,8 @@ end
 
 class InvalidJsonError < Exception
 end
+
+module Nacre
+  class EmptyResourceError < Exception
+  end
+end

--- a/lib/nacre/version.rb
+++ b/lib/nacre/version.rb
@@ -1,3 +1,3 @@
 module Nacre
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
When the client requests a resource that does not exist, instead of sending a 404, the Brightpearl API sends a 200 and an empty resource. Obviously that is not good and causes all kinds of problems if you trust the response status, so we're raising a `Nacre::EmptyResourceError` exception when that happens.