### PR TITLE
Remove `require "pry"`

### DIFF
--- a/lib/nacre/search_results.rb
+++ b/lib/nacre/search_results.rb
@@ -1,5 +1,4 @@
 require "nacre/concerns/inflectible"
-require 'pry'
 
 module Nacre
   class SearchResultsError < ArgumentError; end

--- a/lib/nacre/version.rb
+++ b/lib/nacre/version.rb
@@ -1,3 +1,3 @@
 module Nacre
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
Managed to leave development tools lying around in production.