### PR TITLE
Fix deprecation failure in codeclimate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "coveralls", require: false
-gem "codeclimate-test-reporter", group: :test, require: false
+gem "codeclimate-test-reporter", "~> 1.0.0", group: :test, require: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
-
 require "simplecov"
+
 SimpleCov.start do
   add_filter "/spec/"
   add_filter "/.bundle/"


### PR DESCRIPTION
Code Climate has a new invocation method since 1.0.0 using Simplecov. This removed the deprecated invocation.