### PR TITLE
Extract collection to Collectible module

### DIFF
--- a/lib/nacre/concerns/collectible.rb
+++ b/lib/nacre/concerns/collectible.rb
@@ -1,0 +1,31 @@
+module Nacre::Collectible
+  def self.included(base)
+    base.class_exec do
+      def initialize(resource_list = [])
+        @members = []
+
+        resource_list.each do |resource_params|
+          members << self.class.resource_class.new(resource_params)
+        end
+      end
+    end
+  end
+
+  def members
+    @members
+  end
+
+  def members=(list)
+    @members = list
+  end
+
+  def each(&block)
+    members.each do |member|
+      block.call(member)
+    end
+  end
+
+  def params
+    members.map(&:params)
+  end
+end

--- a/lib/nacre/concerns/collectible.rb
+++ b/lib/nacre/concerns/collectible.rb
@@ -20,7 +20,7 @@ module Nacre
       @members = list
     end
 
-    def each(&block)
+    def each
       members.each do |member|
         yield member
       end

--- a/lib/nacre/concerns/collectible.rb
+++ b/lib/nacre/concerns/collectible.rb
@@ -22,7 +22,7 @@ module Nacre
 
     def each(&block)
       members.each do |member|
-        block.call(member)
+        yield member
       end
     end
 

--- a/lib/nacre/concerns/collectible.rb
+++ b/lib/nacre/concerns/collectible.rb
@@ -2,7 +2,7 @@ module Nacre
   module Collectible
     def self.included(base)
       base.class_exec do
-        def initialize(resource_list = [])
+        def initialize(resource_list = []) # rubocop:disable NestedMethodDefinition
           @members = []
 
           resource_list.each do |resource_params|

--- a/lib/nacre/concerns/collectible.rb
+++ b/lib/nacre/concerns/collectible.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Nacre
   module Collectible
     def self.included(base)

--- a/lib/nacre/concerns/collectible.rb
+++ b/lib/nacre/concerns/collectible.rb
@@ -1,31 +1,33 @@
-module Nacre::Collectible
-  def self.included(base)
-    base.class_exec do
-      def initialize(resource_list = [])
-        @members = []
+module Nacre
+  module Collectible
+    def self.included(base)
+      base.class_exec do
+        def initialize(resource_list = [])
+          @members = []
 
-        resource_list.each do |resource_params|
-          members << self.class.resource_class.new(resource_params)
+          resource_list.each do |resource_params|
+            members << self.class.resource_class.new(resource_params)
+          end
         end
       end
     end
-  end
 
-  def members
-    @members
-  end
-
-  def members=(list)
-    @members = list
-  end
-
-  def each(&block)
-    members.each do |member|
-      block.call(member)
+    def members
+      @members
     end
-  end
 
-  def params
-    members.map(&:params)
+    def members=(list)
+      @members = list
+    end
+
+    def each(&block)
+      members.each do |member|
+        block.call(member)
+      end
+    end
+
+    def params
+      members.map(&:params)
+    end
   end
 end

--- a/lib/nacre/order/invoice_collection.rb
+++ b/lib/nacre/order/invoice_collection.rb
@@ -1,26 +1,12 @@
+require 'nacre/concerns/collectible'
+
 module Nacre
   class Order::InvoiceCollection
-
+    include Collectible
     include Enumerable
 
-    attr_accessor :members
-
-    def initialize(resource_list = [])
-      self.members = []
-      resource_list.each do |resource_params|
-        members << Nacre::Order::Invoice.new(resource_params)
-      end
+    def self.resource_class
+      Nacre::Order::Invoice
     end
-
-    def each(&block)
-      members.each do |member|
-        block.call(member)
-      end
-    end
-
-    def params
-      members.map(&:params)
-    end
-
   end
 end

--- a/lib/nacre/product/sales_channel_collection.rb
+++ b/lib/nacre/product/sales_channel_collection.rb
@@ -1,26 +1,14 @@
+require 'nacre/concerns/collectible'
+
 module Nacre
   class Product::SalesChannelCollection
 
+    include Collectible
     include Enumerable
     extend Inflectible
 
-    attr_accessor :members
-
-    def initialize(resource_list = [])
-      self.members = []
-      resource_list.each do |resource_params|
-        members << Nacre::Product::SalesChannel.new(resource_params)
-      end
-    end
-
-    def each(&block)
-      members.each do |member|
-        block.call(member)
-      end
-    end
-
-    def params
-      members.map(&:params)
+    def self.resource_class
+      Nacre::Product::SalesChannel
     end
 
     def product_name
@@ -34,6 +22,5 @@ module Nacre
         name_sources.first.product_name
       end
     end
-
   end
 end

--- a/lib/nacre/product/sales_channel_collection.rb
+++ b/lib/nacre/product/sales_channel_collection.rb
@@ -1,4 +1,4 @@
-require 'nacre/concerns/collectible'
+require "nacre/concerns/collectible"
 
 module Nacre
   class Product::SalesChannelCollection


### PR DESCRIPTION
This removes some duplication across collections, prior to a re-examination of inheritance throughout the library.